### PR TITLE
Added CLI interface for ad-hoc validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ OpenAPI Spec Validator is a Python library that validates OpenAPI Specs against 
 
 ## Usage
 
+Command Line Interface:
+
+```bash
+$ openapi_spec_validator some.yaml
+```
+
 Validate spec:
 
 ```python

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -32,5 +32,6 @@ def main():
     else:
         print('OK')
 
+
 if __name__ == '__main__':
     main()

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -3,7 +3,7 @@ import argparse
 import os
 import sys
 
-from openapi_spec_validator import validate_spec_url
+from openapi_spec_validator import validate_spec_url, validate_v2_spec_url
 from openapi_spec_validator.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -16,11 +16,24 @@ logging.basicConfig(
 def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filename', help="Absolute or relative path to file")
+    parser.add_argument(
+        '--schema',
+        help="OpenAPI schema (default: 3.0.0)",
+        type=str,
+        choices=['2.0', '3.0.0'],
+        default='3.0.0'
+    )
     args = parser.parse_args(args)
     filename = args.filename
     filename = os.path.abspath(filename)
+    # choose the validator
+    if args.schema == '2.0':
+        validate_url = validate_v2_spec_url
+    elif args.schema == '3.0.0':
+        validate_url = validate_spec_url
+    # validate
     try:
-        validate_spec_url('file://'+filename)
+        validate_url('file://'+filename)
     except ValidationError as e:
         print(e)
         sys.exit(1)

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -13,10 +13,10 @@ logging.basicConfig(
 )
 
 
-def main():
+def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filename', help="Absolute or relative path to file")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     filename = args.filename
     filename = os.path.abspath(filename)
     try:

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -1,5 +1,5 @@
 import logging
-import optparse
+import argparse
 import os
 import sys
 
@@ -14,12 +14,10 @@ logging.basicConfig(
 
 
 def main():
-    usage = 'Usage: %prog filename'
-    parser = optparse.OptionParser(usage)
-    (options, args) = parser.parse_args()
-    if len(args) != 1:
-        parser.error('You must provide a filename to validate')
-    filename = args[0]
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', help="Absolute or relative path to file")
+    args = parser.parse_args()
+    filename = args.filename
     filename = os.path.abspath(filename)
     try:
         validate_spec_url('file://'+filename)

--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -1,0 +1,36 @@
+import logging
+import optparse
+import os
+import sys
+
+from openapi_spec_validator import validate_spec_url
+from openapi_spec_validator.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+    level=logging.WARNING
+)
+
+
+def main():
+    usage = 'Usage: %prog filename'
+    parser = optparse.OptionParser(usage)
+    (options, args) = parser.parse_args()
+    if len(args) != 1:
+        parser.error('You must provide a filename to validate')
+    filename = args[0]
+    filename = os.path.abspath(filename)
+    try:
+        validate_spec_url('file://'+filename)
+    except ValidationError as e:
+        print(e)
+        sys.exit(1)
+    except Exception as e:
+        print(e)
+        sys.exit(2)
+    else:
+        print('OK')
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,11 @@ setup(
         ],
     },
     include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'openapi-spec-validator = openapi_spec_validator.__main__:main'
+        ]
+    },
     install_requires=read_requirements('requirements.txt'),
     tests_require=read_requirements('requirements_dev.txt'),
     cmdclass={'test': PyTest},

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+from openapi_spec_validator.__main__ import main
+
+
+@mock.patch('openapi_spec_validator.__main__.sys')
+def test_nonexisting_file(mock_sys):
+    """Calling with non-existing file should sys.exit."""
+    # the first parameter is always the name of the program itself, so
+    # we can insert a dummy here
+    testargs = ['progname', 'i_dont_exist.yaml']
+    with mock.patch('sys.argv', testargs):
+        assert mock_sys.exit.assert_called
+
+
+@mock.patch('openapi_spec_validator.__main__.sys')
+def test_happy_path(mock_sys):
+    testargs = ['progname', './tests/integration/data/v3.0/petstore.yaml']
+    with mock.patch('sys.argv', testargs):
+        main()
+        assert not mock_sys.exit.called

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -31,6 +31,14 @@ def test_schema_unknown():
         main(testargs)
 
 
+def test_validation_error():
+    """SystemExit on running with ValidationError."""
+    testargs = ['--schema', '3.0.0',
+                './tests/integration/data/v2.0/petstore.yaml']
+    with pytest.raises(SystemExit):
+        main(testargs)
+
+
 def test_nonexisting_file():
     """Calling with non-existing file should sys.exit."""
     testargs = ['i_dont_exist.yaml']

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -3,10 +3,29 @@ import pytest
 from openapi_spec_validator.__main__ import main
 
 
-def test_happy_path():
-    """No errors when calling with proper file."""
+def test_schema_default():
+    """Test default schema is 3.0.0"""
     testargs = ['./tests/integration/data/v3.0/petstore.yaml']
     main(testargs)
+
+
+def test_schema_v3():
+    """No errors when calling proper v3 file."""
+    testargs = ['--schema',  '3.0.0', './tests/integration/data/v3.0/petstore.yaml']
+    main(testargs)
+
+
+def test_schema_v2():
+    """No errors when calling with proper v2 file."""
+    testargs = ['--schema', '2.0', './tests/integration/data/v2.0/petstore.yaml']
+    main(testargs)
+
+
+def test_schema_unknown():
+    """Errors on running with unknown schema."""
+    testargs = ['--schema', 'x.x', './tests/integration/data/v2.0/petstore.yaml']
+    with pytest.raises(SystemExit):
+        main(testargs)
 
 
 def test_nonexisting_file():

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,22 +1,16 @@
-from unittest import mock
+import pytest
 
 from openapi_spec_validator.__main__ import main
 
 
-@mock.patch('openapi_spec_validator.__main__.sys')
-def test_nonexisting_file(mock_sys):
+def test_happy_path():
+    """No errors when calling with proper file."""
+    testargs = ['./tests/integration/data/v3.0/petstore.yaml']
+    main(testargs)
+
+
+def test_nonexisting_file():
     """Calling with non-existing file should sys.exit."""
-    # the first parameter is always the name of the program itself, so
-    # we can insert a dummy here
-    testargs = ['progname', 'i_dont_exist.yaml']
-    with mock.patch('sys.argv', testargs):
-        main()
-        assert mock_sys.exit.called
-
-
-@mock.patch('openapi_spec_validator.__main__.sys')
-def test_happy_path(mock_sys):
-    testargs = ['progname', './tests/integration/data/v3.0/petstore.yaml']
-    with mock.patch('sys.argv', testargs):
-        main()
-        assert not mock_sys.exit.called
+    testargs = ['i_dont_exist.yaml']
+    with pytest.raises(SystemExit):
+        main(testargs)

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -11,19 +11,22 @@ def test_schema_default():
 
 def test_schema_v3():
     """No errors when calling proper v3 file."""
-    testargs = ['--schema',  '3.0.0', './tests/integration/data/v3.0/petstore.yaml']
+    testargs = ['--schema', '3.0.0',
+                './tests/integration/data/v3.0/petstore.yaml']
     main(testargs)
 
 
 def test_schema_v2():
     """No errors when calling with proper v2 file."""
-    testargs = ['--schema', '2.0', './tests/integration/data/v2.0/petstore.yaml']
+    testargs = ['--schema', '2.0',
+                './tests/integration/data/v2.0/petstore.yaml']
     main(testargs)
 
 
 def test_schema_unknown():
     """Errors on running with unknown schema."""
-    testargs = ['--schema', 'x.x', './tests/integration/data/v2.0/petstore.yaml']
+    testargs = ['--schema', 'x.x',
+                './tests/integration/data/v2.0/petstore.yaml']
     with pytest.raises(SystemExit):
         main(testargs)
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -11,7 +11,7 @@ def test_nonexisting_file(mock_sys):
     testargs = ['progname', 'i_dont_exist.yaml']
     with mock.patch('sys.argv', testargs):
         main()
-        assert not mock_sys.exit.called
+        assert mock_sys.exit.called
 
 
 @mock.patch('openapi_spec_validator.__main__.sys')

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -10,7 +10,8 @@ def test_nonexisting_file(mock_sys):
     # we can insert a dummy here
     testargs = ['progname', 'i_dont_exist.yaml']
     with mock.patch('sys.argv', testargs):
-        assert mock_sys.exit.assert_called
+        main()
+        assert not mock_sys.exit.called
 
 
 @mock.patch('openapi_spec_validator.__main__.sys')


### PR DESCRIPTION
Hi,
i've added a CLI interface for validating local files. For that i've created an `entry_point` in `setup.py` pointing to a new file `openapi_spec_validator/__main__.py`. After you installed the package with pip you are able to run
```bash
$ openapi_spec_validator path_to.yaml
```
to run a validation. This could also be extended to run tests on URLs, not just local files.