### PR TITLE
Fixed requirements handling:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
 - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install 'coverage<4.0.0'; fi
 - pip install codecov
 install:
-- pip install -e .
+- pip install -r requirements.txt
 - pip install -r requirements_dev.txt
+- pip install -e .
 script:
 - python setup.py test
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonschema
-pyaml
-six
+jsonschema==2.6.0
+pyaml==17.12.1
+six==1.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
-mock
-pytest
-pytest-pep8
-pytest-flakes
-pytest-cov
-tox
+mock==2.0.0
+pytest==3.5.0
+pytest-pep8==1.0.6
+pytest-flakes==2.0.0
+pytest-cov==2.5.1
+tox==3.0.0rc4

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,6 @@ from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 
-def read_requirements(filename):
-    """Open a requirements file and return list of its lines."""
-    contents = read_file(filename).strip('\n')
-    return contents.split('\n') if contents else []
-
-
 def read_file(filename):
     """Open and a file, read it and return its contents."""
     path = os.path.join(os.path.dirname(__file__), filename)
@@ -67,8 +61,19 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=read_requirements('requirements.txt'),
-    tests_require=read_requirements('requirements_dev.txt'),
+    install_requires=[
+        "jsonschema",
+        "pyaml",
+        "six",
+    ],
+    tests_require=[
+        "mock",
+        "pytest",
+        "pytest-pep8",
+        "pytest-flakes",
+        "pytest-cov",
+        "tox",
+    ],
     cmdclass={'test': PyTest},
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Moved dependencies on packages into setup.py and added version pins in
requirements.txt files.

Also re-ordered the way travis installs:

First we install using requirements.txt (and thus get the desired
versions) then we install using `pip install -e .` which should not
install any new packages.

See:
https://packaging.python.org/discussions/install-requires-vs-requirements/
for current best practises regarding dependency handling.