### PR TITLE
Windows compatibility

### DIFF
--- a/openapi_spec_validator/schemas.py
+++ b/openapi_spec_validator/schemas.py
@@ -2,7 +2,7 @@
 import os
 
 from pkg_resources import resource_filename
-from six.moves.urllib import parse
+from six.moves.urllib import parse, request
 from yaml import safe_load
 
 
@@ -11,7 +11,7 @@ def get_openapi_schema(version):
     path_resource = resource_filename('openapi_spec_validator', path)
     path_full = os.path.join(os.path.dirname(__file__), path_resource)
     schema = read_yaml_file(path_full)
-    schema_url = parse.urljoin('file:', path_full)
+    schema_url = parse.urljoin('file:', request.pathname2url(path_full))
     return schema, schema_url
 
 


### PR DESCRIPTION
Package was not working on Windows, as the file path to the schema used by the script was not properly converted into a valid url on Windows.