### PR TITLE
:bug: Using Int for response code should validate

### DIFF
--- a/openapi_spec_validator/handlers.py
+++ b/openapi_spec_validator/handlers.py
@@ -4,6 +4,7 @@ import contextlib
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.request import urlopen
 from yaml import safe_load
+import json
 
 
 class UrlHandler:
@@ -16,4 +17,4 @@ class UrlHandler:
         assert urlparse(url).scheme in self.allowed_schemes
 
         with contextlib.closing(urlopen(url, timeout=timeout)) as fh:
-            return safe_load(fh)
+            return json.loads(json.dumps(safe_load(fh)))


### PR DESCRIPTION
The underlying schema validation library fails when validating response
with a numeric status code as defined by YAML. This roundtrips the
loaded yaml to and from JSON to provide the validator library with
expected valid json input.