### PR TITLE
add python2.7 compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 matrix:
   include:
+  - python: 2.7
   - python: 3.2
   - python: 3.3
   - python: 3.4

--- a/openapi_spec_validator/decorators.py
+++ b/openapi_spec_validator/decorators.py
@@ -18,7 +18,8 @@ class DerefValidatorDecorator:
     def __call__(self, func):
         def wrapped(validator, schema_element, instance, schema):
             if not isinstance(instance, dict) or '$ref' not in instance:
-                yield from func(validator, schema_element, instance, schema)
+                for res in func(validator, schema_element, instance, schema):
+                    yield res
                 return
 
             ref = instance['$ref']
@@ -30,7 +31,8 @@ class DerefValidatorDecorator:
             self._attach_scope(instance)
             with self.visiting.visit(ref):
                 with self.instance_resolver.resolving(ref) as target:
-                    yield from func(validator, schema_element, target, schema)
+                    for res in func(validator, schema_element, target, schema):
+                        yield res
 
         return wrapped
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     package_data={
         'openapi_spec_validator': [
             'openapi_spec_validator/resources/schemas/v3.0.0/*',
+            'openapi_spec_validator/resources/schemas/v2.0/*',
         ],
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py33,py34,py35,py36}-{default,simplejson}
+envlist = {py27,py33,py34,py35,py36}-{default,simplejson}
 
 [testenv]
 deps =


### PR DESCRIPTION
Hey @p1c2u,
I've really enjoyed your library!
Are you open to supporting python 2.7? I'm using to try to add openapi3 support to a library called connexion (https://github.com/dtkav/connexion/tree/oas3). It would be awesome to depend on your library, but I'd need to be compatible with 2.7 in order to do so.

It looks like only a relatively minor syntax change was needed (don't use `yield from`). Let me know what you think!
