### PR TITLE
OpenAPI 3.0.0 schema fix: Parameter Object must contain 'schema' or 'content'

### DIFF
--- a/openapi_spec_validator/resources/schemas/v3.0.0/schema.json
+++ b/openapi_spec_validator/resources/schemas/v3.0.0/schema.json
@@ -433,7 +433,15 @@
           "content": {
             "$ref": "#/definitions/mediaTypes"
           }
-        }
+        },
+        "oneOf": [
+          {
+            "required": [ "schema" ]
+          },
+          {
+            "required": [ "content" ]
+          }
+        ]
       },
       "requestBody": {
         "type": "object",

--- a/openapi_spec_validator/resources/schemas/v3.0.0/schema.json
+++ b/openapi_spec_validator/resources/schemas/v3.0.0/schema.json
@@ -673,7 +673,15 @@
           "content": {
             "$ref": "#/definitions/mediaTypes"
           }
-        }
+        },
+        "oneOf": [
+          {
+            "required": [ "schema" ]
+          },
+          {
+            "required": [ "content" ]
+          }
+        ]
       },
       "tag": {
         "type": "object",

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -61,10 +61,16 @@ class TestSpecValidatorIterErrors(object):
                         {
                             'name': 'param1',
                             'in': 'query',
+                            'schema': {
+                              'type': 'integer',
+                            },
                         },
                         {
                             'name': 'param1',
                             'in': 'path',
+                            'schema': {
+                              'type': 'integer',
+                            },
                         },
                     ],
                 },
@@ -120,6 +126,9 @@ class TestSpecValidatorIterErrors(object):
                         {
                             'name': 'param1',
                             'in': 'path',
+                            'schema': {
+                                'type': 'integer',
+                            },
                         },
                     ],
                 },


### PR DESCRIPTION
See [the Fixed Fields section of the specs](https://swagger.io/specification/#fixed-fields-51), towards the end:

> A parameter MUST contain either a schema property, or a content property, but not both.

Adding the `oneOf` constraint requiring either `content` or `schema` fixes this issue.

The same issue applies to all objects that refer to Parameter Objects as their basis, such as e.g. Header Objects. I will add to this branch until I've adjusted all of those, and notify when this is done.