### PR TITLE
patch yaml loader to coerce integer keys to strings (fixes #19)

### DIFF
--- a/openapi_spec_validator/schemas.py
+++ b/openapi_spec_validator/schemas.py
@@ -3,7 +3,7 @@ import os
 
 from pkg_resources import resource_filename
 from six.moves.urllib import parse, request
-from yaml import safe_load
+import yaml
 
 
 def get_openapi_schema(version):
@@ -15,7 +15,24 @@ def get_openapi_schema(version):
     return schema, schema_url
 
 
+def yaml_keys_to_strings(self, node, deep=False):
+    """While yaml supports using integer keys, these are not valid in
+       json, and will break jsonschema. This function coerces all keys
+       to strings.
+    """
+    data = self.construct_mapping_org(node, deep)
+    return {
+        (str(key) if isinstance(key, int) else key): data[key]
+        for key in data
+    }
+
+# patch yaml safeloader to ensure that keys are strings
+yaml.SafeLoader.construct_mapping_org = yaml.SafeLoader.construct_mapping
+yaml.SafeLoader.construct_mapping = yaml_keys_to_strings
+
+
 def read_yaml_file(path):
     """Open a file, read it and return its contents."""
+
     with open(path) as fh:
-        return safe_load(fh)
+        return yaml.safe_load(fh)

--- a/tests/integration/data/v2.0/petstore.yaml
+++ b/tests/integration/data/v2.0/petstore.yaml
@@ -27,7 +27,7 @@ paths:
           type: integer
           format: int32
       responses:
-        "200":
+        200:
           description: A paged array of pets
           headers:
             x-next:
@@ -45,7 +45,7 @@ paths:
       tags:
         - pets
       responses:
-        "201":
+        201:
           description: Null response
         default:
           description: unexpected error
@@ -64,7 +64,7 @@ paths:
           description: The id of the pet to retrieve
           type: string
       responses:
-        "200":
+        200:
           description: Expected response to a valid request
           schema:
             $ref: '#/definitions/Pets'


### PR DESCRIPTION
allows yaml specs to have integer responses codes.

while yaml supports loading dict keys as integers, json does not, so yaml files that looked like this:
```
       responses:
         201:
           ...
```
were breaking the swagger and openapi jsonschema validation.

This is more efficient than #18 , which dumps the whole file to json, and then parses it again.