### PR TITLE
wrap jsonschema exceptions with OpenAPIValidationError

### DIFF
--- a/openapi_spec_validator/validators.py
+++ b/openapi_spec_validator/validators.py
@@ -2,10 +2,11 @@ import logging
 import string
 
 from jsonschema.validators import RefResolver
-from six import iteritems
+from six import iteritems, raise_from
 
 from openapi_spec_validator.exceptions import (
     ParameterDuplicateError, ExtraParametersError, UnresolvableParameterError,
+    OpenAPIValidationError
 )
 from openapi_spec_validator.factories import Draft4ExtendedValidatorFactory
 from openapi_spec_validator.managers import ResolverManager
@@ -41,7 +42,7 @@ class SpecValidator(object):
 
     def validate(self, spec, spec_url=''):
         for err in self.iter_errors(spec, spec_url=spec_url):
-            raise err
+            raise_from(OpenAPIValidationError(repr(err)), err)
 
     def iter_errors(self, spec, spec_url=''):
         spec_resolver = self._get_resolver(spec_url, spec)

--- a/openapi_spec_validator/validators.py
+++ b/openapi_spec_validator/validators.py
@@ -2,6 +2,7 @@ import logging
 import string
 
 from jsonschema.validators import RefResolver
+from jsonschema.exceptions import ValidationError
 from six import iteritems, raise_from
 
 from openapi_spec_validator.exceptions import (
@@ -42,7 +43,11 @@ class SpecValidator(object):
 
     def validate(self, spec, spec_url=''):
         for err in self.iter_errors(spec, spec_url=spec_url):
-            raise_from(OpenAPIValidationError(repr(err)), err)
+            if isinstance(err, ValidationError):
+                # wrap jsonschema exceptions with library specific version
+                raise raise_from(OpenAPIValidationError.create_from(err), err)
+            else:
+                raise err
 
     def iter_errors(self, spec, spec_url=''):
         spec_resolver = self._get_resolver(spec_url, spec)

--- a/tests/integration/test_shortcuts.py
+++ b/tests/integration/test_shortcuts.py
@@ -1,9 +1,8 @@
 import pytest
 
-from jsonschema.exceptions import ValidationError
-
 from openapi_spec_validator import validate_spec, validate_spec_url
 from openapi_spec_validator import validate_v2_spec, validate_v2_spec_url
+from openapi_spec_validator.exceptions import OpenAPIValidationError
 
 
 class BaseTestValidValidteV2Spec:
@@ -15,7 +14,7 @@ class BaseTestValidValidteV2Spec:
 class BaseTestFaliedValidateV2Spec:
 
     def test_failed(self, spec):
-        with pytest.raises(ValidationError):
+        with pytest.raises(OpenAPIValidationError):
             validate_v2_spec(spec)
 
 
@@ -28,7 +27,7 @@ class BaseTestValidValidteSpec:
 class BaseTestFaliedValidateSpec:
 
     def test_failed(self, spec):
-        with pytest.raises(ValidationError):
+        with pytest.raises(OpenAPIValidationError):
             validate_spec(spec)
 
 
@@ -41,7 +40,7 @@ class BaseTestValidValidteV2SpecUrl:
 class BaseTestFaliedValidateV2SpecUrl:
 
     def test_failed(self, spec_url):
-        with pytest.raises(ValidationError):
+        with pytest.raises(OpenAPIValidationError):
             validate_v2_spec_url(spec_url)
 
 
@@ -54,7 +53,7 @@ class BaseTestValidValidteSpecUrl:
 class BaseTestFaliedValidateSpecUrl:
 
     def test_failed(self, spec_url):
-        with pytest.raises(ValidationError):
+        with pytest.raises(OpenAPIValidationError):
             validate_spec_url(spec_url)
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jsonschema.exceptions import ValidationError
+from openapi_spec_validator.exceptions import OpenAPIValidationError
 
 
 class BaseTestValidOpeAPIv3Validator(object):
@@ -20,7 +20,7 @@ class BaseTestFailedOpeAPIv3Validator(object):
         return ''
 
     def test_failed(self, validator, spec, spec_url):
-        with pytest.raises(ValidationError):
+        with pytest.raises(OpenAPIValidationError):
             validator.validate(spec, spec_url=spec_url)
 
 


### PR DESCRIPTION
Fixes #20 

### Proposed changes:
- wrap jsonschema `ValidationError`s in `OpenAPIValidationError`, which inherits from `ValidationError`

This allows the user to expect a consistent error to be raised if the exception is invalid.
Note that with the use of `six.raise_from(...)` the original exception is preserved via exception chaining in python 3.
I think this is best practice, _but_ it may be annoying because each exception essentially prints twice.

### Examples:
test script, `try.py`:
```python
#!/usr/bin/env python
import yaml
from openapi_spec_validator import validate_spec
with open("openapi.yaml") as f:
    y = yaml.load(f.read())
validate_spec(y)
```
python 3:
```
> python3 try.py
jsonschema.exceptions.ValidationError: 'somestring' is not of type 'integer'

Failed validating 'type' in schema:
    {'default': 'somestring', 'type': 'integer'}

On instance:
    'somestring'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "try.py", line 9, in <module>
    validate_spec(y)
  File "/home/daniel/stash/openapi-spec-validator/openapi_spec_validator/shortcuts.py", line 7, in validate
    return validator_callable(spec, spec_url=spec_url)
  File "/home/daniel/stash/openapi-spec-validator/openapi_spec_validator/validators.py", line 48, in validate
    raise raise_from(OpenAPIValidationError.create_from(err), err)
  File "<string>", line 3, in raise_from
openapi_spec_validator.exceptions.OpenAPIValidationError: 'somestring' is not of type 'integer'

Failed validating 'type' in schema:
    {'default': 'somestring', 'type': 'integer'}

On instance:
    'somestring'
```
python 2:
```
> python2 try.py
Traceback (most recent call last):
  File "try.py", line 9, in <module>
    validate_spec(y)
  File "/home/daniel/stash/openapi-spec-validator/openapi_spec_validator/shortcuts.py", line 7, in validate
    return validator_callable(spec, spec_url=spec_url)
  File "/home/daniel/stash/openapi-spec-validator/openapi_spec_validator/validators.py", line 48, in validate
    raise raise_from(OpenAPIValidationError.create_from(err), err)
  File "/home/daniel/.local/lib/python2.7/site-packages/six.py", line 737, in raise_from
    raise value
openapi_spec_validator.exceptions.OpenAPIValidationError: 'somestring' is not of type 'integer'

Failed validating 'type' in schema:
    {'default': 'somestring', 'type': 'integer'}

On instance:
    'somestring'
```