### PR TITLE
Switch test requirement to pytest-flake8.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 mock==2.0.0
 pytest==3.5.0
-pytest-pep8==1.0.6
-pytest-flakes==2.0.0
+pytest-flake8
 pytest-cov==2.5.1
 tox==3.0.0rc4

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ class PyTest(TestCommand):
         TestCommand.finalize_options(self)
         self.test_args = [
             '-sv',
-            '--pep8',
-            '--flakes',
+            '--flake8',
             '--cov', 'openapi_spec_validator',
             '--cov-report', 'term-missing',
         ]
@@ -75,8 +74,7 @@ setup(
     tests_require=[
         "mock",
         "pytest",
-        "pytest-pep8",
-        "pytest-flakes",
+        "pytest-flake8",
         "pytest-cov",
         "tox",
     ],


### PR DESCRIPTION
Flake8 runs both pyflakes and pycodestyle. Pep8 is deprecated and renamed to pycodestyle.