### PR TITLE
Signal PyPI to format the long_description as Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     url=metadata['url'],
     license=metadata['license'],
     long_description=read_file('README.md'),
+    long_description_content_type='text/markdown',
     packages=find_packages(include=('openapi_spec_validator*',)),
     package_data={
         'openapi_spec_validator': [


### PR DESCRIPTION
Should make the page at https://pypi.org/project/openapi-spec-validator/ render as Markdown. See: https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata