### PR TITLE
revert pyyaml requirement version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ from openapi_spec_validator import openapi_v3_spec_validator
 errors_iterator = openapi_v3_spec_validator.iter_errors(spec)
 ```
 
+## Security Note
+
+PyYAML, a requirement of this project, has a
+[security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2017-18342)
+in the default implementation of `yaml.load()`, which allows execution
+of arbitrary code while loading a target file or stream.  OpenAPI Spec
+Validator uses a safe loader to ensure that only Python objects
+marked as safe can be executed.  Thus, you are not exposed to this
+vulnerability by using this package.
+
+If you use `PyYAML` directly, be sure to use `yaml.safe_load()` to
+avoid inadvertantly exposing youself to potentially malicous data.  The
+[PyYAML docs](https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml)
+describe this issue in detail.
+
 ## Related projects
 
 * [openapi-core](https://github.com/p1c2u/openapi-core) is a Python library that adds client-side and server-side support for the OpenAPI.

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     },
     install_requires=[
         "jsonschema<3",
-        "PyYAML>=4.2b1",
+        "PyYAML>=3.13",
         "six",
         'pathlib;python_version=="2.7"',
     ],


### PR DESCRIPTION
Don't require a beta version of PyYAML to solve a security issue we're not exposed to.

See discussion in #60 

I'll add a security note in the README too.