### PR TITLE
Replace pathlib with pathlib2

### DIFF
--- a/openapi_spec_validator/__main__.py
+++ b/openapi_spec_validator/__main__.py
@@ -1,7 +1,10 @@
 import logging
 import argparse
 import os
-import pathlib
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
 import sys
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "jsonschema<3",
         "PyYAML>=3.13",
         "six",
-        'pathlib;python_version=="2.7"',
+        'pathlib2;python_version=="2.7"',
     ],
     tests_require=[
         "mock",


### PR DESCRIPTION
[pathlib](https://bitbucket.org/pitrou/pathlib)  isn't maintained anymore. So maybe pathlib2 is a better choice

Fixes #63