### PR TITLE
Support jsonschema 3

### DIFF
--- a/openapi_spec_validator/generators.py
+++ b/openapi_spec_validator/generators.py
@@ -2,7 +2,7 @@
 import logging
 
 from six import iteritems
-from jsonschema import _validators
+from jsonschema.validators import Draft4Validator
 
 from openapi_spec_validator.decorators import DerefValidatorDecorator
 
@@ -13,21 +13,20 @@ class SpecValidatorsGeneratorFactory:
     """Generator factory for customized validators that follows $refs
     in the schema being validated.
     """
-
     validators = {
-        '$ref': _validators.ref,
-        'properties': _validators.properties_draft4,
-        'additionalProperties': _validators.additionalProperties,
-        'patternProperties': _validators.patternProperties,
-        'type': _validators.type_draft4,
-        'dependencies': _validators.dependencies,
-        'required': _validators.required_draft4,
-        'minProperties': _validators.minProperties_draft4,
-        'maxProperties': _validators.maxProperties_draft4,
-        'allOf': _validators.allOf_draft4,
-        'oneOf': _validators.oneOf_draft4,
-        'anyOf': _validators.anyOf_draft4,
-        'not': _validators.not_draft4,
+        '$ref',
+        'properties',
+        'additionalProperties',
+        'patternProperties',
+        'type',
+        'dependencies',
+        'required',
+        'minProperties',
+        'maxProperties',
+        'allOf',
+        'oneOf',
+        'anyOf',
+        'not',
     }
 
     @classmethod
@@ -38,5 +37,6 @@ class SpecValidatorsGeneratorFactory:
         :type instance_resolver: :class:`jsonschema.RefResolver`
         """
         deref = DerefValidatorDecorator(spec_resolver)
-        for key, validator_callable in iteritems(cls.validators):
-            yield key, deref(validator_callable)
+        for key, validator_callable in iteritems(Draft4Validator.VALIDATORS):
+            if key in cls.validators:
+                yield key, deref(validator_callable)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jsonschema==2.6.0
+jsonschema
 PyYAML==4.2b4
 six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         ]
     },
     install_requires=[
-        "jsonschema<3",
+        "jsonschema",
         "PyYAML>=5.1",
         "six",
         'pathlib2;python_version=="2.7"',


### PR DESCRIPTION
Avoid hard coding the validator functions in SpecValidatorsGeneratorFactory and just use the defaults in Draft4Validator.

This allows us to work with both > and < jsonschema 3.

I wasn't sure if we actually need the list of validators to be a subset of what is in Draft4Validator. If we don't we can simplify this a little.