### PR TITLE
Add a short description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     author_email=metadata['email'],
     url=metadata['url'],
     license=metadata['license'],
+    description='OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0.0 spec validator',
     long_description=read_file('README.md'),
     long_description_content_type='text/markdown',
     packages=find_packages(include=('openapi_spec_validator*',)),


### PR DESCRIPTION
The short description will show up when doing a `pip3 search openapi-spec-validator` and the short description is also used by external tools.

For example the gitlab license tools takes, in order, description then long description. In this case, the long description is the contents of README.md: eg: https://jlecomte.gitlab.io/-/projects/rd-webhooks/-/jobs/325696880/artifacts/gl-license-management-report.json
