### PR TITLE
Add Python 3.8 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   - python: 3.5
   - python: 3.6
   - python: 3.7
+  - python: 3.8
     dist: xenial
     sudo: true
   - python: nightly


### PR DESCRIPTION
Adds Python 3.8 to the testing matrix