### PR TITLE
A `$ref` may be a property name and in such cases it's not hashable

### DIFF
--- a/openapi_spec_validator/decorators.py
+++ b/openapi_spec_validator/decorators.py
@@ -18,7 +18,8 @@ class DerefValidatorDecorator:
 
     def __call__(self, func):
         def wrapped(validator, schema_element, instance, schema):
-            if not isinstance(instance, dict) or '$ref' not in instance:
+            if (not isinstance(instance, dict) or '$ref' not in instance
+                    or not instance['$ref'].__hash__):
                 for res in func(validator, schema_element, instance, schema):
                     yield res
                 return

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -93,6 +93,8 @@ components:
           type: string
         tag:
           type: string
+        $ref:
+          type: string
     Pets:
       type: array
       items:


### PR DESCRIPTION
This is not a "proper fix" as the proper fix should check if `$ref`
is used as a name of the property, but this works for the purposes of #123

fixes #123