### PR TITLE
Recurse references in validation

### DIFF
--- a/openapi_spec_validator/validators.py
+++ b/openapi_spec_validator/validators.py
@@ -34,6 +34,8 @@ class Dereferencer(object):
         ref = item['$ref']
         with self.resolver_manager.in_scope(item) as resolver:
             with resolver.resolving(ref) as target:
+                if is_ref(target):
+                    target = self.dereference(target)
                 return target
 
 

--- a/tests/integration/data/v3.0/parent-reference/openapi.yaml
+++ b/tests/integration/data/v3.0/parent-reference/openapi.yaml
@@ -14,6 +14,7 @@ paths:
       tags:
         - pets
       parameters:
+        - $ref: "recursive.yaml#/parameters/RecursiveReference"
         - name: limit
           in: query
           description: How many items to return at one time (max 100)

--- a/tests/integration/data/v3.0/parent-reference/recursive.yaml
+++ b/tests/integration/data/v3.0/parent-reference/recursive.yaml
@@ -1,0 +1,3 @@
+parameters:
+  RecursiveReference:
+    $ref : "recursive2.yaml#/parameters/RecursiveReference"

--- a/tests/integration/data/v3.0/parent-reference/recursive2.yaml
+++ b/tests/integration/data/v3.0/parent-reference/recursive2.yaml
@@ -1,0 +1,8 @@
+parameters:
+  RecursiveReference:
+    name: sampleParameter
+    in: query
+    description: Tests recursion
+    required: false
+    schema:
+      type: boolean

--- a/tests/integration/test_shortcuts.py
+++ b/tests/integration/test_shortcuts.py
@@ -156,7 +156,7 @@ class TestPetstoreExample(BaseTestValidValidateV3SpecUrl):
         )
 
 
-class TestApiWithExampe(BaseTestValidValidateV3SpecUrl):
+class TestApiWithExample(BaseTestValidValidateV3SpecUrl):
 
     @pytest.fixture
     def spec_url(self):


### PR DESCRIPTION
JSON schema references can be nested in complex schemas.
Recurse in dereferencing logic until the returned item is no
longer a reference.

Also: Added a recursion to test data and fixed a typo
in test_shortcuts.py.