### PR TITLE
On validation error: add cause and context.

### DIFF
--- a/tests/integration/data/v3.0/missing-description.yaml
+++ b/tests/integration/data/v3.0/missing-description.yaml
@@ -1,0 +1,18 @@
+---
+openapi: 3.0.0
+
+info:
+  title: test
+  description: test
+  version: 0.0.1
+
+paths:
+  "/":
+    get:
+      description: Get the API root
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: string

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -26,6 +26,33 @@ def test_schema_v2():
     main(testargs)
 
 
+def test_errors_on_missing_description_best(capsys):
+    """An error is obviously printed given an empty schema."""
+    testargs = ['./tests/integration/data/v3.0/missing-description.yaml']
+    with pytest.raises(SystemExit):
+        main(testargs)
+    out, err = capsys.readouterr()
+    assert "Failed validating" in out
+    assert "'description' is a required property" in out
+    assert "'$ref' is a required property" not in out
+    assert '1 more subschemas errors' in out
+
+
+def test_errors_on_missing_description_full(capsys):
+    """An error is obviously printed given an empty schema."""
+    testargs = [
+        "./tests/integration/data/v3.0/missing-description.yaml",
+        "--errors=all"
+    ]
+    with pytest.raises(SystemExit):
+        main(testargs)
+    out, err = capsys.readouterr()
+    assert "Failed validating" in out
+    assert "'description' is a required property" in out
+    assert "'$ref' is a required property" in out
+    assert '1 more subschema error' not in out
+
+
 def test_schema_unknown():
     """Errors on running with unknown schema."""
     testargs = ['--schema', 'x.x',


### PR DESCRIPTION
I often miss the context provided by jsonschema library, so I'm trying to add it.

Given the following erroneous schema (it misses a `description`):

```yaml
---
openapi: 3.0.0

info:
  title: test
  description: test
  version: 0.0.1

paths:
  "/":
    get:
      description: Get the API root
      responses:
        200:
          content:
            application/json:
              schema:
                type: string
```

without this PR, openapi-spec-validator displays:

```
{'content': {'application/json': {'schema': {'type': 'string'}}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$'
]['properties']['responses']['patternProperties']['^[1-5](?:\\d{2}|XX)$']:
    {'oneOf': [{'$ref': '#/definitions/Response'},
               {'$ref': '#/definitions/Reference'}]}

On instance['paths']['/']['get']['responses']['200']:
    {'content': {'application/json': {'schema': {'type': 'string'}}}}
```

Basically telling « The `path./.get.responses.200` is invalid: it should be a Response or a Reference. » without telling me about the missing `description`.

With this PR it gives:
```
{'content': {'application/json': {'schema': {'type': 'string'}}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['responses']['patternProperties']['^[1-5](?:\\d{2}|XX)$']:
    {'oneOf': [{'$ref': '#/definitions/Response'},
               {'$ref': '#/definitions/Reference'}]}

On instance['paths']['/']['get']['responses']['200']:
    {'content': {'application/json': {'schema': {'type': 'string'}}}}


Due to those subschema errors:

'description' is a required property

Failed validating 'required' in schema[0]:
    {'additionalProperties': False,
     'patternProperties': {'^x-': {}},
     'properties': {'content': {'additionalProperties': {'$ref': '#/definitions/MediaType'},
                                'type': 'object'},
                    'description': {'type': 'string'},
                    'headers': {'additionalProperties': {'oneOf': [{'$ref': '#/definitions/Header'},
                                                                   {'$ref': '#/definitions/Reference'}]},
                                'type': 'object'},
                    'links': {'additionalProperties': {'oneOf': [{'$ref': '#/definitions/Link'},
                                                                 {'$ref': '#/definitions/Reference'}]},
                              'type': 'object'}},
     'required': ['description'],
     'type': 'object'}

On instance:
    {'content': {'application/json': {'schema': {'type': 'string'}}}}


'$ref' is a required property

Failed validating 'required' in schema[1]:
    {'patternProperties': {'^\\$ref$': {'format': 'uri-reference',
                                        'type': 'string'}},
     'required': ['$ref'],
     'type': 'object'}

On instance:
    {'content': {'application/json': {'schema': {'type': 'string'}}}}
```

This is probably a bit verbose, but I like a lot seeing `'description' is a required property`.