### PR TITLE
Update pyproject.toml - add version to setuptools 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ openapi-schema-validator = {version = "^0.3.0a1", allow-prereleases = true}
 python = "^3.7.0"
 PyYAML = ">=5.1"
 requests = {version = "*", optional = true}
-setuptools = "*"
+setuptools = "^60.9.3"
 
 [tool.poetry.extras]
 dev = ["pre-commit"]


### PR DESCRIPTION
Fix error when using the openapi-spec-validator package while deploying Python Function App in Microsoft Azure.
Add version to setuptools in toml file.
Resolve this error:
`ERROR: In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    setuptools from https://files.pythonhosted.org/packages/3b/02/8d4d27b1cacaac2d129a27d17a22d92a2a5eedcb7817d4ed8ab0d4daf5c4/setuptools-60.9.3-py3-none-any.whl#sha256=e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b (from openapi-spec-validator==0.4.0->-r requirements.txt (line 180))`