### PR TITLE
Drop no longer used runtime dependency on PyYAML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ classifiers = [
 jsonschema = "^4.0.0"
 openapi-schema-validator = "^0.3.2"
 python = "^3.7.0"
-PyYAML = ">=5.1"
 requests = {version = "*", optional = true}
 importlib-resources = "^5.8.0"
 jsonschema-spec = "^0.1.1"


### PR DESCRIPTION
PyYAML is no longer runtime dependency (7bca8cd and 7cbc3f6).
`openapi-spec-validator` requires `jsonschema-spec` that in turn wants `PyYAML = ">=5.1"`.

Fixes: https://github.com/p1c2u/openapi-spec-validator/issues/179