### PR TITLE
Fix an errant string identity comparison in a test

### DIFF
--- a/tests/integration/validation/test_exceptions.py
+++ b/tests/integration/validation/test_exceptions.py
@@ -465,7 +465,7 @@ class TestSpecValidatorIterErrors:
 
         @oas30_format_checker.checks("custom")
         def validate(to_validate) -> bool:
-            return to_validate is "valid"
+            return to_validate == "valid"
 
         spec = {
             "openapi": "3.0.0",


### PR DESCRIPTION
Short strings can be interned as an optimization in the Python interpreter, so comparing them by identity (`is`, memory address) can succeed in practice, but it is neither correct nor reliable when comparing by equality (`==`, value) is intended.

Fixes a warning (that could become a test failure depending on interpreter implementation details):

```
tests/integration/validation/test_exceptions.py:468
  /builddir/build/BUILD/openapi-spec-validator-0.5.2/tests/integration/validation/test_exceptions.py:468: SyntaxWarning: "is" with a literal. Did you mean "=="?
    return to_validate is "valid"
```